### PR TITLE
Version 0.5.0

### DIFF
--- a/bump-version.sh
+++ b/bump-version.sh
@@ -17,8 +17,12 @@ to=$2
 grep "^version = \"$from\"" "$crate_name/Cargo.toml" > /dev/null || (echo "Wrong version: $from" && exit 1)
 
 # update package versions
-sed -i "" -e "s/^version = \"$from\"/version = \"$to\"/" "$crate_name/Cargo.toml"
-sed -i "" -e "s/^version = \"$from\"/version = \"$to\"/" "${crate_name}_derive/Cargo.toml"
+# these sed incantations are portable across BSD and GNU sed
+sed -i.bak -e "s/^version = \"$from\"/version = \"$to\"/" "$crate_name/Cargo.toml"
+sed -i.bak -e "s/^version = \"$from\"/version = \"$to\"/" "${crate_name}_derive/Cargo.toml"
 
 # update main crate's dev dependency on derive crate (if any)
-sed -i "" -e "s/\(${crate_name}_derive.*version\) = \"$from\"/\1 = \"$to\"/" "$crate_name/Cargo.toml"
+sed -i.bak -e "s/\(${crate_name}_derive.*version\) = \"$from\"/\1 = \"$to\"/" "$crate_name/Cargo.toml"
+
+rm "$crate_name/Cargo.toml.bak"
+rm "${crate_name}_derive/Cargo.toml.bak"

--- a/ssz/Cargo.toml
+++ b/ssz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum_ssz"
-version = "1.0.0-beta.2"
+version = "0.5.0"
 edition = "2021"
 description = "SimpleSerialize (SSZ) as used in Ethereum"
 license = "Apache-2.0"
@@ -14,7 +14,7 @@ categories = ["cryptography::cryptocurrencies"]
 name = "ssz"
 
 [dev-dependencies]
-ethereum_ssz_derive = { version = "1.0.0-beta.2", path = "../ssz_derive" }
+ethereum_ssz_derive = { version = "0.5.0", path = "../ssz_derive" }
 
 [dependencies]
 ethereum-types = "0.14.1"

--- a/ssz_derive/Cargo.toml
+++ b/ssz_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum_ssz_derive"
-version = "1.0.0-beta.2"
+version = "0.5.0"
 edition = "2021"
 description = "Procedural derive macros to accompany the ethereum_ssz crate"
 license = "Apache-2.0"


### PR DESCRIPTION
This version resumes the `0.x` series indefinitely due to the `ethereum-types` dependency still being `0.x`. It would be reckless to release this crate as `1.x` while pinning the `ethereum-types` dependency as we wouldn't be able to update it without breaking semver.

This PR also makes the version bump script cross-platform (I originally wrote it on a Mac)