### PR TITLE
Version 0.5.1

### DIFF
--- a/ssz/Cargo.toml
+++ b/ssz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum_ssz"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "SimpleSerialize (SSZ) as used in Ethereum"
 license = "Apache-2.0"
@@ -14,7 +14,7 @@ categories = ["cryptography::cryptocurrencies"]
 name = "ssz"
 
 [dev-dependencies]
-ethereum_ssz_derive = { version = "0.5.0", path = "../ssz_derive" }
+ethereum_ssz_derive = { version = "0.5.1", path = "../ssz_derive" }
 
 [dependencies]
 ethereum-types = "0.14.1"

--- a/ssz/src/decode/impls.rs
+++ b/ssz/src/decode/impls.rs
@@ -421,6 +421,7 @@ impl_for_vec!(SmallVec<[T; 5]>, None);
 impl_for_vec!(SmallVec<[T; 6]>, None);
 impl_for_vec!(SmallVec<[T; 7]>, None);
 impl_for_vec!(SmallVec<[T; 8]>, None);
+impl_for_vec!(SmallVec<[T; 96]>, None);
 
 impl<K, V> Decode for BTreeMap<K, V>
 where

--- a/ssz/src/encode/impls.rs
+++ b/ssz/src/encode/impls.rs
@@ -335,6 +335,7 @@ impl_for_vec!(SmallVec<[T; 5]>);
 impl_for_vec!(SmallVec<[T; 6]>);
 impl_for_vec!(SmallVec<[T; 7]>);
 impl_for_vec!(SmallVec<[T; 8]>);
+impl_for_vec!(SmallVec<[T; 96]>);
 
 impl<K, V> Encode for BTreeMap<K, V>
 where

--- a/ssz_derive/Cargo.toml
+++ b/ssz_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum_ssz_derive"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "Procedural derive macros to accompany the ethereum_ssz crate"
 license = "Apache-2.0"


### PR DESCRIPTION
_Release early, release often._

This has changes required for `tree-states`, namely decode+encode impls for 96-byte smallvecs, which we need for uncompressed public keys: https://github.com/sigp/lighthouse/issues/3505.