### PR TITLE
Use `path` for circular dev-dependency

### DIFF
--- a/ssz_derive/Cargo.toml
+++ b/ssz_derive/Cargo.toml
@@ -21,4 +21,4 @@ quote = "1.0.7"
 darling = "0.13.0"
 
 [dev-dependencies]
-ethereum_ssz = { version = "0.5.2", path = "../ssz" }
+ethereum_ssz = { path = "../ssz" }


### PR DESCRIPTION
This hack was necessary to publish v0.5.2.

The automated release should succeed for future releases.