### PR TITLE
Add code coverage

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -33,3 +33,18 @@ jobs:
       run: cargo test --release
     - name: Check all examples, binaries, etc
       run: cargo check --all-targets
+  coverage:
+    runs-on: ubuntu-latest
+    name: cargo-tarpaulin
+    steps:
+    - uses: actions/checkout@v3
+    - name: Get latest version of stable Rust
+      run: rustup update stable
+    - name: Install cargo-tarpaulin
+      uses: taiki-e/install-action@cargo-tarpaulin
+    - name: Check code coverage with cargo-tarpaulin
+      run: cargo-tarpaulin --workspace --all-features --out xml
+    - name: Upload to codecov.io
+      uses: codecov/codecov-action@v2
+      with:
+        fail_ci_if_error: true

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -45,6 +45,7 @@ jobs:
     - name: Check code coverage with cargo-tarpaulin
       run: cargo-tarpaulin --workspace --all-features --out xml
     - name: Upload to codecov.io
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Install cargo-tarpaulin
       uses: taiki-e/install-action@cargo-tarpaulin
     - name: Check code coverage with cargo-tarpaulin
-      run: cargo-tarpaulin --workspace --all-features --out xml
+      run: make coverage
     - name: Upload to codecov.io
       uses: codecov/codecov-action@v4
       with:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -45,6 +45,6 @@ jobs:
     - name: Check code coverage with cargo-tarpaulin
       run: cargo-tarpaulin --workspace --all-features --out xml
     - name: Upload to codecov.io
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Cargo.lock
 target
+cobertura.xml

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+# These hacks are required for the test binaries depending on the dynamic library libstd-*.so
+# See: https://github.com/rust-lang/cargo/issues/4651
+coverage:
+	env LD_LIBRARY_PATH="$(shell rustc --print sysroot)/lib" \
+	cargo-tarpaulin --workspace --all-features --out xml
+
+.PHONY: coverage


### PR DESCRIPTION
Adds code coverage using `cargo-tarpaulin` and uploads the results to codecov.io to generate a coverage report.