### PR TITLE
Add derive `Decode` for transparent enums

### DIFF
--- a/ssz/src/decode.rs
+++ b/ssz/src/decode.rs
@@ -51,6 +51,8 @@ pub enum DecodeError {
     BytesInvalid(String),
     /// The given union selector is out of bounds.
     UnionSelectorInvalid(u8),
+    /// The given bytes could not be successfully decoded into any variant of the transparent enum.
+    NoMatchingVariant,
 }
 
 /// Performs checks on the `offset` based upon the other parameters provided.

--- a/ssz_derive/tests/tests.rs
+++ b/ssz_derive/tests/tests.rs
@@ -1,4 +1,4 @@
-use ssz::{Decode, Encode, DecodeError};
+use ssz::{Decode, DecodeError, Encode};
 use ssz_derive::{Decode, Encode};
 use std::fmt::Debug;
 use std::marker::PhantomData;

--- a/ssz_derive/tests/tests.rs
+++ b/ssz_derive/tests/tests.rs
@@ -1,4 +1,4 @@
-use ssz::{Decode, Encode};
+use ssz::{Decode, Encode, DecodeError};
 use ssz_derive::{Decode, Encode};
 use std::fmt::Debug;
 use std::marker::PhantomData;
@@ -56,14 +56,14 @@ struct VariableB {
     b: u8,
 }
 
-#[derive(PartialEq, Debug, Encode)]
+#[derive(PartialEq, Debug, Encode, Decode)]
 #[ssz(enum_behaviour = "transparent")]
 enum TwoVariableTrans {
     A(VariableA),
     B(VariableB),
 }
 
-#[derive(PartialEq, Debug, Encode)]
+#[derive(PartialEq, Debug, Encode, Decode)]
 struct TwoVariableTransStruct {
     a: TwoVariableTrans,
 }
@@ -91,16 +91,24 @@ fn two_variable_trans() {
         b: 3,
     });
 
-    assert_encode(&trans_a, &[1, 5, 0, 0, 0, 2, 3]);
-    assert_encode(&trans_b, &[5, 0, 0, 0, 3, 1, 2]);
+    assert_encode_decode(&trans_a, &[1, 5, 0, 0, 0, 2, 3]);
+    assert_encode_decode(&trans_b, &[5, 0, 0, 0, 3, 1, 2]);
 
-    assert_encode(
+    assert_encode_decode(
         &TwoVariableTransStruct { a: trans_a },
         &[4, 0, 0, 0, 1, 5, 0, 0, 0, 2, 3],
     );
-    assert_encode(
+    assert_encode_decode(
         &TwoVariableTransStruct { a: trans_b },
         &[4, 0, 0, 0, 5, 0, 0, 0, 3, 1, 2],
+    );
+}
+
+#[test]
+fn trans_enum_error() {
+    assert_eq!(
+        TwoVariableTrans::from_ssz_bytes(&[1, 3, 0, 0, 0]).unwrap_err(),
+        DecodeError::NoMatchingVariant,
     );
 }
 


### PR DESCRIPTION
## Summary

Adds support for deriving `ssz::Decode` on `#[ssz(enum_behaviour = "transparent")]` enums by attempting to decode all variants in order until one is successful.  Returns `ssz::DecodeError::NoMatchingVariant` if none can be successfully decoded.  This is the same approach used by serde for their [untagged enum representation](https://serde.rs/enum-representations#untagged).

## Motivation

This is useful in situations where we are expecting one of a few distinctly decodable types.  

## Considerations

In some cases, the ordering of the enum variants will matter and this may not always be obvious to the user.  The user must be careful not to include a variant that will "shadow" subsequent variants.  It would be ideal to warn/panic in these cases.  (Is this possible?)