### PR TITLE
chore(deps): change ethereum-types to alloy-primitives

### DIFF
--- a/ssz/Cargo.toml
+++ b/ssz/Cargo.toml
@@ -14,12 +14,13 @@ categories = ["cryptography::cryptocurrencies"]
 name = "ssz"
 
 [dev-dependencies]
+alloy-primitives = { version = "0.7.0", features = ["getrandom"] }
 ethereum_ssz_derive = { version = "0.5.3", path = "../ssz_derive" }
 
 [dependencies]
-ethereum-types = "0.14.1"
+alloy-primitives = "0.7.0"
 smallvec = { version = "1.6.1", features = ["const_generics"] }
 itertools = "0.10.3"
 
 [features]
-arbitrary = ["ethereum-types/arbitrary"]
+arbitrary = ["alloy-primitives/arbitrary"]

--- a/ssz/src/decode/impls.rs
+++ b/ssz/src/decode/impls.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::decode::try_from_iter::{TryCollect, TryFromIter};
+use alloy_primitives::{Address, B256, U128, U256};
 use core::num::NonZeroUsize;
-use ethereum_types::{H160, H256, U128, U256};
 use itertools::process_results;
 use smallvec::SmallVec;
 use std::collections::{BTreeMap, BTreeSet};
@@ -274,7 +274,7 @@ impl<T: Decode> Decode for Arc<T> {
     }
 }
 
-impl Decode for H160 {
+impl Decode for Address {
     fn is_ssz_fixed_len() -> bool {
         true
     }
@@ -295,7 +295,7 @@ impl Decode for H160 {
     }
 }
 
-impl Decode for H256 {
+impl Decode for B256 {
     fn is_ssz_fixed_len() -> bool {
         true
     }
@@ -311,7 +311,7 @@ impl Decode for H256 {
         if len != expected {
             Err(DecodeError::InvalidByteLength { len, expected })
         } else {
-            Ok(H256::from_slice(bytes))
+            Ok(B256::from_slice(bytes))
         }
     }
 }
@@ -332,7 +332,7 @@ impl Decode for U256 {
         if len != expected {
             Err(DecodeError::InvalidByteLength { len, expected })
         } else {
-            Ok(U256::from_little_endian(bytes))
+            Ok(U256::from_le_slice(bytes))
         }
     }
 }
@@ -353,7 +353,7 @@ impl Decode for U128 {
         if len != expected {
             Err(DecodeError::InvalidByteLength { len, expected })
         } else {
-            Ok(U128::from_little_endian(bytes))
+            Ok(U128::from_le_slice(bytes))
         }
     }
 }
@@ -575,9 +575,9 @@ mod tests {
     }
 
     #[test]
-    fn invalid_h256() {
+    fn invalid_b256() {
         assert_eq!(
-            H256::from_ssz_bytes(&[0; 33]),
+            B256::from_ssz_bytes(&[0; 33]),
             Err(DecodeError::InvalidByteLength {
                 len: 33,
                 expected: 32
@@ -585,7 +585,7 @@ mod tests {
         );
 
         assert_eq!(
-            H256::from_ssz_bytes(&[0; 31]),
+            B256::from_ssz_bytes(&[0; 31]),
             Err(DecodeError::InvalidByteLength {
                 len: 31,
                 expected: 32

--- a/ssz/src/encode/impls.rs
+++ b/ssz/src/encode/impls.rs
@@ -1,6 +1,6 @@
 use super::*;
+use alloy_primitives::{Address, B256, U128, U256};
 use core::num::NonZeroUsize;
-use ethereum_types::{H160, H256, U128, U256};
 use smallvec::SmallVec;
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
@@ -408,7 +408,7 @@ impl Encode for NonZeroUsize {
     }
 }
 
-impl Encode for H160 {
+impl Encode for Address {
     fn is_ssz_fixed_len() -> bool {
         true
     }
@@ -422,11 +422,11 @@ impl Encode for H160 {
     }
 
     fn ssz_append(&self, buf: &mut Vec<u8>) {
-        buf.extend_from_slice(self.as_bytes());
+        buf.extend_from_slice(self.as_slice());
     }
 }
 
-impl Encode for H256 {
+impl Encode for B256 {
     fn is_ssz_fixed_len() -> bool {
         true
     }
@@ -440,7 +440,7 @@ impl Encode for H256 {
     }
 
     fn ssz_append(&self, buf: &mut Vec<u8>) {
-        buf.extend_from_slice(self.as_bytes());
+        buf.extend_from_slice(self.as_slice());
     }
 }
 
@@ -458,11 +458,7 @@ impl Encode for U256 {
     }
 
     fn ssz_append(&self, buf: &mut Vec<u8>) {
-        let n = <Self as Encode>::ssz_fixed_len();
-        let s = buf.len();
-
-        buf.resize(s + n, 0);
-        self.to_little_endian(&mut buf[s..]);
+        buf.extend_from_slice(self.as_le_slice());
     }
 }
 
@@ -480,11 +476,7 @@ impl Encode for U128 {
     }
 
     fn ssz_append(&self, buf: &mut Vec<u8>) {
-        let n = <Self as Encode>::ssz_fixed_len();
-        let s = buf.len();
-
-        buf.resize(s + n, 0);
-        self.to_little_endian(&mut buf[s..]);
+        buf.extend_from_slice(self.as_le_slice());
     }
 }
 
@@ -606,16 +598,16 @@ mod tests {
     }
 
     #[test]
-    fn ssz_encode_h256() {
-        assert_eq!(H256::from(&[0; 32]).as_ssz_bytes(), vec![0; 32]);
-        assert_eq!(H256::from(&[1; 32]).as_ssz_bytes(), vec![1; 32]);
+    fn ssz_encode_b256() {
+        assert_eq!(B256::from(&[0; 32]).as_ssz_bytes(), vec![0; 32]);
+        assert_eq!(B256::from(&[1; 32]).as_ssz_bytes(), vec![1; 32]);
 
         let bytes = vec![
             1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0,
         ];
 
-        assert_eq!(H256::from_slice(&bytes).as_ssz_bytes(), bytes);
+        assert_eq!(B256::from_slice(&bytes).as_ssz_bytes(), bytes);
     }
 
     #[test]

--- a/ssz/tests/tests.rs
+++ b/ssz/tests/tests.rs
@@ -1,8 +1,9 @@
-use ethereum_types::H256;
 use ssz::{Decode, DecodeError, Encode};
 use ssz_derive::{Decode, Encode};
 
 mod round_trip {
+    use alloy_primitives::B256;
+
     use super::*;
     use std::collections::BTreeMap;
     use std::iter::FromIterator;
@@ -37,28 +38,28 @@ mod round_trip {
     }
 
     #[test]
-    fn h256() {
-        let items: Vec<H256> = vec![H256::zero(), H256::from([1; 32]), H256::random()];
+    fn b256() {
+        let items: Vec<B256> = vec![B256::ZERO, B256::from([1; 32]), B256::random()];
 
         round_trip(items);
     }
 
     #[test]
-    fn vec_of_h256() {
-        let items: Vec<Vec<H256>> = vec![
+    fn vec_of_b256() {
+        let items: Vec<Vec<B256>> = vec![
             vec![],
-            vec![H256::zero(), H256::from([1; 32]), H256::random()],
+            vec![B256::ZERO, B256::from([1; 32]), B256::random()],
         ];
 
         round_trip(items);
     }
 
     #[test]
-    fn option_vec_h256() {
-        let items: Vec<Option<Vec<H256>>> = vec![
+    fn option_vec_b256() {
+        let items: Vec<Option<Vec<B256>>> = vec![
             None,
             Some(vec![]),
-            Some(vec![H256::zero(), H256::from([1; 32]), H256::random()]),
+            Some(vec![B256::ZERO, B256::from([1; 32]), B256::random()]),
         ];
 
         round_trip(items);


### PR DESCRIPTION
@michaelsproul ping for review

Updating ethereum-types to alloy-primitives.

I believe Lighthouse is planning to move to alloy as well, so here is a PR as we rely on this library too and are moving to alloy