### PR TITLE
Add u128

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,4 @@ members = [
     "ssz",
     "ssz_derive",
 ]
+resolver = "2"

--- a/ssz/src/decode/impls.rs
+++ b/ssz/src/decode/impls.rs
@@ -40,6 +40,7 @@ impl_decodable_for_uint!(u8, 8);
 impl_decodable_for_uint!(u16, 16);
 impl_decodable_for_uint!(u32, 32);
 impl_decodable_for_uint!(u64, 64);
+impl_decodable_for_uint!(u128, 128);
 
 #[cfg(target_pointer_width = "32")]
 impl_decodable_for_uint!(usize, 32);
@@ -773,5 +774,23 @@ mod tests {
             <(u16, u16)>::from_ssz_bytes(&[255, 255, 0, 0]),
             Ok((65535, 0))
         );
+    }
+
+    #[test]
+    fn vec_of_u128_roundtrip() {
+        let values = vec![
+            vec![0u128, 55u128, u128::MAX, u128::MAX - 3],
+            vec![],
+            vec![u128::MAX],
+            vec![u32::MAX as u128],
+            vec![0, 0, 0, 0],
+            vec![0, 0, 0, 0, 0, 0],
+        ];
+        for vec in values {
+            assert_eq!(
+                Vec::<u128>::from_ssz_bytes(&vec.as_ssz_bytes()).unwrap(),
+                vec
+            );
+        }
     }
 }

--- a/ssz/src/encode/impls.rs
+++ b/ssz/src/encode/impls.rs
@@ -31,6 +31,7 @@ impl_encodable_for_uint!(u8, 8);
 impl_encodable_for_uint!(u16, 16);
 impl_encodable_for_uint!(u32, 32);
 impl_encodable_for_uint!(u64, 64);
+impl_encodable_for_uint!(u128, 128);
 
 #[cfg(target_pointer_width = "32")]
 impl_encodable_for_uint!(usize, 32);
@@ -579,6 +580,18 @@ mod tests {
         assert_eq!(
             (!0_u64).as_ssz_bytes(),
             vec![255, 255, 255, 255, 255, 255, 255, 255]
+        );
+    }
+
+    #[test]
+    fn ssz_encode_u128() {
+        assert_eq!(
+            1_u128.as_ssz_bytes(),
+            vec![1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        );
+        assert_eq!(
+            (!0_u128).as_ssz_bytes(),
+            vec![255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]
         );
     }
 


### PR DESCRIPTION
Add suppport for encoding and decoding `u128`. This is in accordance with the spec which defines `uint`s for all bit lengths up to 256: https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md#basic-types.

Closes:

- https://github.com/sigp/ethereum_ssz/issues/17