### PR TITLE
Version 0.5.4

### DIFF
--- a/ssz/Cargo.toml
+++ b/ssz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum_ssz"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 description = "SimpleSerialize (SSZ) as used in Ethereum"
 license = "Apache-2.0"
@@ -14,7 +14,7 @@ categories = ["cryptography::cryptocurrencies"]
 name = "ssz"
 
 [dev-dependencies]
-ethereum_ssz_derive = { version = "0.5.3", path = "../ssz_derive" }
+ethereum_ssz_derive = { version = "0.5.4", path = "../ssz_derive" }
 
 [dependencies]
 ethereum-types = "0.14.1"

--- a/ssz_derive/Cargo.toml
+++ b/ssz_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum_ssz_derive"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 description = "Procedural derive macros to accompany the ethereum_ssz crate"
 license = "Apache-2.0"


### PR DESCRIPTION
New release with `u128` support and `derive(Decode)` for transparent enums.

This is a patch release because there are no breaking changes.