### PR TITLE
Release v0.6.0

### DIFF
--- a/ssz/Cargo.toml
+++ b/ssz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum_ssz"
-version = "0.5.4"
+version = "0.6.0"
 edition = "2021"
 description = "SimpleSerialize (SSZ) as used in Ethereum"
 license = "Apache-2.0"
@@ -15,7 +15,7 @@ name = "ssz"
 
 [dev-dependencies]
 alloy-primitives = { version = "0.7.7", features = ["getrandom"] }
-ethereum_ssz_derive = { version = "0.5.4", path = "../ssz_derive" }
+ethereum_ssz_derive = { version = "0.6.0", path = "../ssz_derive" }
 
 [dependencies]
 alloy-primitives = "0.7.7"

--- a/ssz_derive/Cargo.toml
+++ b/ssz_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum_ssz_derive"
-version = "0.5.4"
+version = "0.6.0"
 edition = "2021"
 description = "Procedural derive macros to accompany the ethereum_ssz crate"
 license = "Apache-2.0"


### PR DESCRIPTION
New release with the big breaking change to remove `ethereum-types` in favour of `alloy-primitives`.

We will need to do another minor release when `alloy-primitives 0.8` is released sans dependency on `ethereum_ssz`.