### PR TITLE
Update alloy-primitives to 0.8

### DIFF
--- a/ssz/Cargo.toml
+++ b/ssz/Cargo.toml
@@ -14,11 +14,11 @@ categories = ["cryptography::cryptocurrencies"]
 name = "ssz"
 
 [dev-dependencies]
-alloy-primitives = { version = "0.7.7", features = ["getrandom"] }
+alloy-primitives = { version = "0.8.0", features = ["getrandom"] }
 ethereum_ssz_derive = { version = "0.6.0", path = "../ssz_derive" }
 
 [dependencies]
-alloy-primitives = "0.7.7"
+alloy-primitives = "0.8.0"
 smallvec = { version = "1.6.1", features = ["const_generics"] }
 itertools = "0.13.0"
 


### PR DESCRIPTION
Resolve the circular dependency issue with `alloy-primitives` after the release of:

- https://github.com/alloy-rs/core/pull/701