### PR TITLE
feat: impl Encode Decode for alloy_primitves::Bloom

### DIFF
--- a/ssz/src/decode/impls.rs
+++ b/ssz/src/decode/impls.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::decode::try_from_iter::{TryCollect, TryFromIter};
-use alloy_primitives::{Address, Bytes, FixedBytes, U128, U256};
+use alloy_primitives::{Address, Bloom, Bytes, FixedBytes, U128, U256};
 use core::num::NonZeroUsize;
 use itertools::process_results;
 use smallvec::SmallVec;
@@ -317,6 +317,27 @@ impl<const N: usize> Decode for FixedBytes<N> {
         fixed_array.copy_from_slice(bytes);
 
         Ok(Self(fixed_array))
+    }
+}
+
+impl Decode for Bloom {
+    fn is_ssz_fixed_len() -> bool {
+        true
+    }
+
+    fn ssz_fixed_len() -> usize {
+        256
+    }
+
+    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
+        let len = bytes.len();
+        let expected = <Self as Decode>::ssz_fixed_len();
+
+        if len != expected {
+            Err(DecodeError::InvalidByteLength { len, expected })
+        } else {
+            Ok(Self::from_slice(bytes))
+        }
     }
 }
 

--- a/ssz/src/encode/impls.rs
+++ b/ssz/src/encode/impls.rs
@@ -1,5 +1,5 @@
 use super::*;
-use alloy_primitives::{Address, Bytes, FixedBytes, U128, U256};
+use alloy_primitives::{Address, Bloom, Bytes, FixedBytes, U128, U256};
 use core::num::NonZeroUsize;
 use smallvec::SmallVec;
 use std::collections::{BTreeMap, BTreeSet};
@@ -446,6 +446,33 @@ impl<const N: usize> Encode for FixedBytes<N> {
     #[inline]
     fn ssz_append(&self, buf: &mut Vec<u8>) {
         buf.extend_from_slice(&self.0);
+    }
+
+    #[inline]
+    fn as_ssz_bytes(&self) -> Vec<u8> {
+        self.0.to_vec()
+    }
+}
+
+impl Encode for Bloom {
+    #[inline]
+    fn is_ssz_fixed_len() -> bool {
+        true
+    }
+
+    #[inline]
+    fn ssz_bytes_len(&self) -> usize {
+        256
+    }
+
+    #[inline]
+    fn ssz_fixed_len() -> usize {
+        256
+    }
+
+    #[inline]
+    fn ssz_append(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&self.0 .0);
     }
 
     #[inline]

--- a/ssz/tests/tests.rs
+++ b/ssz/tests/tests.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{Address, Bytes, B256, U128, U256};
+use alloy_primitives::{Address, Bloom, Bytes, B256, U128, U256};
 use ssz::{Decode, DecodeError, Encode};
 use ssz_derive::{Decode, Encode};
 use std::num::NonZeroUsize;
@@ -540,6 +540,26 @@ mod round_trip {
         let data = vec![(48u8, Some(0u64)), (0u8, None), (u8::MAX, Some(u64::MAX))];
         round_trip(data);
     }
+
+    #[test]
+    fn bloom() {
+        let data = vec![
+            Bloom::ZERO,
+            Bloom::with_last_byte(5),
+            Bloom::repeat_byte(73),
+        ];
+        round_trip(data);
+    }
+
+    #[test]
+    fn vec_bloom() {
+        let data = vec![
+            vec![Bloom::ZERO, Bloom::ZERO, Bloom::with_last_byte(5)],
+            vec![],
+            vec![Bloom::repeat_byte(73), Bloom::repeat_byte(72)],
+        ];
+        round_trip(data);
+    }
 }
 
 /// Decode tests that are expected to fail.
@@ -562,5 +582,11 @@ mod decode_fail {
     fn hash256() {
         let long_bytes = vec![0xff; 257];
         assert!(B256::from_ssz_bytes(&long_bytes).is_err());
+    }
+
+    #[test]
+    fn bloom() {
+        let long_bytes = vec![0xff; 33];
+        assert!(Bloom::from_ssz_bytes(&long_bytes).is_err());
     }
 }

--- a/ssz/tests/tests.rs
+++ b/ssz/tests/tests.rs
@@ -580,13 +580,13 @@ mod decode_fail {
 
     #[test]
     fn hash256() {
-        let long_bytes = vec![0xff; 257];
+        let long_bytes = vec![0xff; 33];
         assert!(B256::from_ssz_bytes(&long_bytes).is_err());
     }
 
     #[test]
     fn bloom() {
-        let long_bytes = vec![0xff; 33];
+        let long_bytes = vec![0xff; 257];
         assert!(Bloom::from_ssz_bytes(&long_bytes).is_err());
     }
 }


### PR DESCRIPTION
## Motivation 

Missing `Encode` and `Decode` for `alloy_primitives::Bloom`, which is required here https://github.com/alloy-rs/alloy/pull/1167.

## Solution

implement `Encode` and `Decode` for `Bloom`