### PR TITLE
Release v0.8.0

### DIFF
--- a/ssz/Cargo.toml
+++ b/ssz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum_ssz"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 description = "SimpleSerialize (SSZ) as used in Ethereum"
 license = "Apache-2.0"
@@ -15,7 +15,7 @@ name = "ssz"
 
 [dev-dependencies]
 alloy-primitives = { version = "0.8.0", features = ["getrandom"] }
-ethereum_ssz_derive = { version = "0.7.1", path = "../ssz_derive" }
+ethereum_ssz_derive = { version = "0.8.0", path = "../ssz_derive" }
 
 [dependencies]
 alloy-primitives = "0.8.0"

--- a/ssz_derive/Cargo.toml
+++ b/ssz_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum_ssz_derive"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 description = "Procedural derive macros to accompany the ethereum_ssz crate"
 license = "Apache-2.0"


### PR DESCRIPTION
New v0.8.0 release for the addition of `BitList`/`BitVector`.

Although adding the new types is only a minor change, I've chosen to bump the effective major version (the second digit) due to the addition of new dependencies which might break builds for users on the v0.7.x series. This change _feels_ more major than a simple patch version bump.