### PR TITLE
chore: remove derivative dep

### DIFF
--- a/ssz/Cargo.toml
+++ b/ssz/Cargo.toml
@@ -25,7 +25,6 @@ itertools = "0.13.0"
 serde = "1.0.0"
 serde_derive = "1.0.0"
 typenum = "1.12.0"
-derivative = "2.1.1"
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
 
 [features]

--- a/ssz/src/bitfield.rs
+++ b/ssz/src/bitfield.rs
@@ -110,7 +110,7 @@ pub type BitVector<N> = Bitfield<Fixed<N>>;
 /// The internal representation of the bitfield is the same as that required by SSZ. The lowest
 /// byte (by `Vec` index) stores the lowest bit-indices and the right-most bit stores the lowest
 /// bit-index. E.g., `smallvec![0b0000_0001, 0b0000_0010]` has bits `0, 9` set.
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct Bitfield<T> {
     bytes: SmallVec<[u8; SMALLVEC_LEN]>,
     len: usize,
@@ -541,22 +541,6 @@ impl<T: BitfieldBehaviour> Bitfield<T> {
                 len: self.len(),
             })
         }
-    }
-}
-
-impl<T> Eq for Bitfield<T> {}
-impl<T> PartialEq for Bitfield<T> {
-    #[inline]
-    fn eq(&self, other: &Bitfield<T>) -> bool {
-        self.len == other.len && self.bytes == other.bytes
-    }
-}
-
-impl<T> core::hash::Hash for Bitfield<T> {
-    #[inline]
-    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
-        core::hash::Hash::hash(&self.bytes, state);
-        core::hash::Hash::hash(&self.len, state);
     }
 }
 

--- a/ssz/src/bitfield.rs
+++ b/ssz/src/bitfield.rs
@@ -1,6 +1,5 @@
 use crate::{Decode, DecodeError, Encode};
 use core::marker::PhantomData;
-use derivative::Derivative;
 use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
 use serde_utils::hex::{encode as hex_encode, PrefixedHexVisitor};
@@ -111,8 +110,7 @@ pub type BitVector<N> = Bitfield<Fixed<N>>;
 /// The internal representation of the bitfield is the same as that required by SSZ. The lowest
 /// byte (by `Vec` index) stores the lowest bit-indices and the right-most bit stores the lowest
 /// bit-index. E.g., `smallvec![0b0000_0001, 0b0000_0010]` has bits `0, 9` set.
-#[derive(Clone, Debug, Derivative)]
-#[derivative(PartialEq, Eq, Hash(bound = ""))]
+#[derive(Clone, Debug)]
 pub struct Bitfield<T> {
     bytes: SmallVec<[u8; SMALLVEC_LEN]>,
     len: usize,
@@ -543,6 +541,22 @@ impl<T: BitfieldBehaviour> Bitfield<T> {
                 len: self.len(),
             })
         }
+    }
+}
+
+impl<T> Eq for Bitfield<T> {}
+impl<T> PartialEq for Bitfield<T> {
+    #[inline]
+    fn eq(&self, other: &Bitfield<T>) -> bool {
+        self.len == other.len && self.bytes == other.bytes
+    }
+}
+
+impl<T> core::hash::Hash for Bitfield<T> {
+    #[inline]
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        core::hash::Hash::hash(&self.bytes, state);
+        core::hash::Hash::hash(&self.len, state);
     }
 }
 


### PR DESCRIPTION
there's an advisory for derivative https://rustsec.org/advisories/RUSTSEC-2024-0388

replaces derivative dep with the expanded code (omits phantom field, because noop)

expanded code on main:

```rust
    #[allow(unused_qualifications)]
    impl<T> ::std::cmp::Eq for Bitfield<T> {}
    #[allow(unused_qualifications)]
    impl<T> ::std::hash::Hash for Bitfield<T> {
        fn hash<__HT>(&self, __state: &mut __HT)
        where
            __HT: ::std::hash::Hasher,
        {
            match *self {
                Bitfield {
                    bytes: ref __arg_0,
                    len: ref __arg_1,
                    _phantom: ref __arg_2,
                } => {
                    ::std::hash::Hash::hash(&(*__arg_0), __state);
                    ::std::hash::Hash::hash(&(*__arg_1), __state);
                    ::std::hash::Hash::hash(&(*__arg_2), __state);
                }
            }
        }
    }
    #[allow(unused_qualifications)]
    #[allow(clippy::unneeded_field_pattern)]
    impl<T> ::std::cmp::PartialEq for Bitfield<T> {
        fn eq(&self, other: &Self) -> bool {
            true
                && match *self {
                    Bitfield {
                        bytes: ref __self_0,
                        len: ref __self_1,
                        _phantom: ref __self_2,
                    } => {
                        match *other {
                            Bitfield {
                                bytes: ref __other_0,
                                len: ref __other_1,
                                _phantom: ref __other_2,
                            } => {
                                true && &(*__self_0) == &(*__other_0)
                                    && &(*__self_1) == &(*__other_1)
                                    && &(*__self_2) == &(*__other_2)
                            }
                        }
                    }
                }
        }
    }
```