### PR TITLE
Bump `Bitfield` smallvec to 128 to avoid heap allocations

### DIFF
--- a/ssz/src/bitfield.rs
+++ b/ssz/src/bitfield.rs
@@ -26,9 +26,10 @@ pub enum Error {
 
 /// Maximum number of bytes to store on the stack in a bitfield's `SmallVec`.
 ///
-/// The default of 32 bytes is enough to take us through to ~500K validators, as the byte length of
-/// attestation bitfields is roughly `N // 32 slots // 64 committes // 8 bits`.
-pub const SMALLVEC_LEN: usize = 32;
+/// 128 bytes is enough to take us through to ~2M active validators, as the byte
+/// length of attestation bitfields is roughly `N // 32 slots // 64 committes //
+/// 8 bits`.
+pub const SMALLVEC_LEN: usize = 128;
 
 /// A marker trait applied to `Variable` and `Fixed` that defines the behaviour of a `Bitfield`.
 pub trait BitfieldBehaviour: Clone {}


### PR DESCRIPTION
Increases the size of the `Bitfield` on the stack to 128 bytes. If the `smallvec` exceeds this then it will allocate to the heap.

This has the effect of ensuring that the `Attestation` bitfield can live on the stack for all networks with up to ~2M validators.

Allocating the `Attestation` to the heap is slow and increase memory fragmentation. This affects attestation deserialisation (happens very frequently) and block deserialisation (happens less frequently, but is latency critical).
 
 ## Why 80 bytes?
 
The number of validators supported by a given bitfield size is `N * 32 slots * 64 committees * 8 bits`.

At the time of writing, mainnet has ~1.1M active validators and Holesky has ~1.76M.

128 is a nice round multiple of 8 that fits Holesky without putting too much on the stack.

## Notes

This PR originally appeared at https://github.com/sigp/ssz_types/pull/35
