### PR TITLE
Release v0.8.1

### DIFF
--- a/ssz/Cargo.toml
+++ b/ssz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum_ssz"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 description = "SimpleSerialize (SSZ) as used in Ethereum"
 license = "Apache-2.0"
@@ -15,7 +15,7 @@ name = "ssz"
 
 [dev-dependencies]
 alloy-primitives = { version = "0.8.0", features = ["getrandom"] }
-ethereum_ssz_derive = { version = "0.8.0", path = "../ssz_derive" }
+ethereum_ssz_derive = { version = "0.8.1", path = "../ssz_derive" }
 
 [dependencies]
 alloy-primitives = "0.8.0"

--- a/ssz_derive/Cargo.toml
+++ b/ssz_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum_ssz_derive"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 description = "Procedural derive macros to accompany the ethereum_ssz crate"
 license = "Apache-2.0"


### PR DESCRIPTION
New release for removal of `derivative` (backwards compatible) and smallvec change (also backwards compatible):

- https://github.com/sigp/ethereum_ssz/pull/38