### PR TITLE
Simplify fixed decoding in derive macro

### DIFF
--- a/ssz_derive/src/lib.rs
+++ b/ssz_derive/src/lib.rs
@@ -823,7 +823,7 @@ fn ssz_decode_derive_struct(item: &DeriveInput, struct_data: &DataStruct) -> Tok
         fixed_decodes.push(quote! {
             let (slice, bytes) = bytes
                 .split_at_checked(#ssz_fixed_len)
-                .ok_or_else(|| ssz::DecodeError::InvalidByteLength {
+                .ok_or(ssz::DecodeError::InvalidByteLength {
                     len: bytes.len(),
                     expected: #ssz_fixed_len
                 })?;

--- a/ssz_derive/src/lib.rs
+++ b/ssz_derive/src/lib.rs
@@ -821,12 +821,7 @@ fn ssz_decode_derive_struct(item: &DeriveInput, struct_data: &DataStruct) -> Tok
         }
 
         fixed_decodes.push(quote! {
-            let (slice, bytes) = bytes
-                .split_at_checked(#ssz_fixed_len)
-                .ok_or(ssz::DecodeError::InvalidByteLength {
-                    len: bytes.len(),
-                    expected: #ssz_fixed_len
-                })?;
+            let (slice, bytes) = bytes.split_at(#ssz_fixed_len);
             let #ident = #from_ssz_bytes?;
         });
         is_fixed_lens.push(is_ssz_fixed_len);


### PR DESCRIPTION
Simplifies how we decode a fixed-length struct using the derive macro. My reasoning is:

- I find this implementation simpler to read.
- I also understands it avoids one `checked_add` and one bounds check per decoding, which is unlikely to be impactful but it's a nice-to-have.

## Safety argument

It's clear that `slice` will always be exactly `#ssz_fixed_len`.

There will be no trailing bytes after all the `split_at`s due to the `bytes.len() != <Self as ssz::Decode>::ssz_fixed_len()` at the start of the encoding. This assumes the integrity of `Self::ssz_fixed_len`, but that's an existing and fair assumption.

We will never panic during `split_at` if we uphold the assumption in the previous paragraph.