### PR TITLE
Export `bitfield::Error`

### DIFF
--- a/ssz/src/lib.rs
+++ b/ssz/src/lib.rs
@@ -41,7 +41,7 @@ pub mod legacy;
 mod union_selector;
 
 #[doc(hidden)]
-pub use bitfield::{BitList, BitVector, Bitfield, Fixed, Variable};
+pub use bitfield::{BitList, BitVector, Bitfield, Error as BitfieldError, Fixed, Variable};
 pub use decode::{
     impls::decode_list_of_variable_length_items, read_offset, split_union_bytes,
     try_from_iter::TryFromIter, Decode, DecodeError, SszDecoder, SszDecoderBuilder,


### PR DESCRIPTION
Exports the error returned by `Bitfield`, `BitList` and `BitVector`.