### PR TITLE
Release v0.8.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,5 +22,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Publish derive crate
         run: cargo publish -p ethereum_ssz_derive
+      # `ethereum_ssz` depends on `ethereum_ssz_derive` to publish, so sleep a
+      # bit to give crates.io some time to update.
+      - name: Sleep for 3 minutes
+        run: sleep 180s
+        shell: bash
       - name: Publish main crate
         run: cargo publish -p ethereum_ssz

--- a/ssz/Cargo.toml
+++ b/ssz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum_ssz"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 description = "SimpleSerialize (SSZ) as used in Ethereum"
 license = "Apache-2.0"
@@ -15,7 +15,7 @@ name = "ssz"
 
 [dev-dependencies]
 alloy-primitives = { version = "0.8.0", features = ["getrandom"] }
-ethereum_ssz_derive = { version = "0.8.1", path = "../ssz_derive" }
+ethereum_ssz_derive = { version = "0.8.2", path = "../ssz_derive" }
 
 [dependencies]
 alloy-primitives = "0.8.0"

--- a/ssz_derive/Cargo.toml
+++ b/ssz_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum_ssz_derive"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 description = "Procedural derive macros to accompany the ethereum_ssz crate"
 license = "Apache-2.0"


### PR DESCRIPTION
New release to export `BitfieldError`: https://github.com/sigp/ethereum_ssz/pull/41

This PR also includes a CI modification to address https://github.com/sigp/ethereum_ssz/pull/39#issuecomment-2518873159