### PR TITLE
Release v0.8.3

### DIFF
--- a/ssz/Cargo.toml
+++ b/ssz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum_ssz"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 description = "SimpleSerialize (SSZ) as used in Ethereum"
 license = "Apache-2.0"
@@ -15,7 +15,7 @@ name = "ssz"
 
 [dev-dependencies]
 alloy-primitives = { version = "0.8.0", features = ["getrandom"] }
-ethereum_ssz_derive = { version = "0.8.2", path = "../ssz_derive" }
+ethereum_ssz_derive = { version = "0.8.3", path = "../ssz_derive" }
 
 [dependencies]
 alloy-primitives = "0.8.0"

--- a/ssz_derive/Cargo.toml
+++ b/ssz_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethereum_ssz_derive"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 description = "Procedural derive macros to accompany the ethereum_ssz crate"
 license = "Apache-2.0"


### PR DESCRIPTION
New minor (effectively patch) release for generic `[u8; N]` and `SmallVec<[u8; N]>` implementations.

This is backwards-compatible for users of `0.8.x`, hence the small version bump (no need to go to `0.9`).