### PR TITLE
chore(deps): alloy-primitives 1.0

### DIFF
--- a/ssz/Cargo.toml
+++ b/ssz/Cargo.toml
@@ -14,11 +14,11 @@ categories = ["cryptography::cryptocurrencies"]
 name = "ssz"
 
 [dev-dependencies]
-alloy-primitives = { version = "0.8.0", features = ["getrandom"] }
+alloy-primitives = { version = "=1.0.0-rc.1", features = ["getrandom"] }
 ethereum_ssz_derive = { version = "0.8.3", path = "../ssz_derive" }
 
 [dependencies]
-alloy-primitives = "0.8.0"
+alloy-primitives = "=1.0.0-rc.1"
 ethereum_serde_utils = "0.7.0"
 smallvec = { version = "1.6.1", features = ["const_generics"] }
 itertools = "0.13.0"

--- a/ssz/Cargo.toml
+++ b/ssz/Cargo.toml
@@ -14,11 +14,11 @@ categories = ["cryptography::cryptocurrencies"]
 name = "ssz"
 
 [dev-dependencies]
-alloy-primitives = { version = "=1.0.0-rc.1", features = ["getrandom"] }
+alloy-primitives = { version = "1.0", features = ["getrandom"] }
 ethereum_ssz_derive = { version = "0.8.3", path = "../ssz_derive" }
 
 [dependencies]
-alloy-primitives = "=1.0.0-rc.1"
+alloy-primitives = "1.0"
 ethereum_serde_utils = "0.7.0"
 smallvec = { version = "1.6.1", features = ["const_generics"] }
 itertools = "0.13.0"

--- a/ssz/Cargo.toml
+++ b/ssz/Cargo.toml
@@ -19,7 +19,7 @@ ethereum_ssz_derive = { version = "0.8.3", path = "../ssz_derive" }
 
 [dependencies]
 alloy-primitives = "1.0"
-ethereum_serde_utils = "0.7.0"
+ethereum_serde_utils = "0.8.0"
 smallvec = { version = "1.6.1", features = ["const_generics"] }
 itertools = "0.13.0"
 serde = "1.0.0"

--- a/ssz/src/bitfield.rs
+++ b/ssz/src/bitfield.rs
@@ -565,7 +565,7 @@ impl<T> core::hash::Hash for Bitfield<T> {
 ///
 /// `bit_len == 0` requires a single byte.
 fn bytes_for_bit_len(bit_len: usize) -> usize {
-    std::cmp::max(1, (bit_len + 7) / 8)
+    std::cmp::max(1, bit_len.div_ceil(8))
 }
 
 /// An iterator over the bits in a `Bitfield`.

--- a/ssz_derive/src/lib.rs
+++ b/ssz_derive/src/lib.rs
@@ -9,18 +9,18 @@
 //! - `#[ssz(enum_behaviour = "tag")]`: encodes and decodes an `enum` with 0 fields per variant
 //! - `#[ssz(enum_behaviour = "union")]`: encodes and decodes an `enum` with a one-byte variant selector.
 //! - `#[ssz(enum_behaviour = "transparent")]`: allows encoding an `enum` by serializing only the
-//!     value whilst ignoring outermost the `enum`.  decodes by attempting to decode each variant
-//!     in order and the first one that is successful is returned.
+//!   value whilst ignoring outermost the `enum`.  decodes by attempting to decode each variant
+//!   in order and the first one that is successful is returned.
 //! - `#[ssz(struct_behaviour = "container")]`: encodes and decodes the `struct` as an SSZ
-//!     "container".
+//!   "container".
 //! - `#[ssz(struct_behaviour = "transparent")]`: encodes and decodes a `struct` with exactly one
-//!     non-skipped field as if the outermost `struct` does not exist.
+//!   non-skipped field as if the outermost `struct` does not exist.
 //!
 //! The following field attributes are available:
 //!
 //! - `#[ssz(with = "module")]`: uses the methods in `module` to implement `ssz::Encode` and
-//!     `ssz::Decode`. This is useful when it's not possible to create an `impl` for that type
-//!     (e.g. the type is defined in another crate).
+//!   `ssz::Decode`. This is useful when it's not possible to create an `impl` for that type
+//!   (e.g. the type is defined in another crate).
 //! - `#[ssz(skip_serializing)]`: this field will not be included in the serialized SSZ vector.
 //! - `#[ssz(skip_deserializing)]`: this field will not be expected in the serialized
 //!   SSZ vector and it will be initialized from a `Default` implementation.


### PR DESCRIPTION
alloy-primitives 1.0 has been released https://crates.io/crates/alloy-primitives/1.0.0

We've prepared a PR to bump alloy as well https://github.com/alloy-rs/alloy/pull/2184

In order to do this we need an ethereum_ssz release that includes the bumped primitives, Pre-requisite: https://github.com/sigp/ethereum_serde_utils/pull/16