### PR TITLE
Faster uint decoding

### DIFF
--- a/ssz/src/decode/impls.rs
+++ b/ssz/src/decode/impls.rs
@@ -11,14 +11,17 @@ use std::sync::Arc;
 macro_rules! impl_decodable_for_uint {
     ($type: ident, $bit_size: expr) => {
         impl Decode for $type {
+            #[inline(always)]
             fn is_ssz_fixed_len() -> bool {
                 true
             }
 
+            #[inline(always)]
             fn ssz_fixed_len() -> usize {
                 $bit_size / 8
             }
 
+            #[inline(always)]
             fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
                 let len = bytes.len();
                 let expected = <Self as Decode>::ssz_fixed_len();


### PR DESCRIPTION
This PR optimises integer decoding by inlining the decoding functions aggressively.

The speedup is around 60% for `u8` per benchmarks from this PR:

- https://github.com/sigp/ssz_types/pull/55

```
decode_fixed_vector/u8_128k
                        time:   [118.56 µs 119.22 µs 119.99 µs]
                        change: [−61.759% −61.667% −61.573%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Inlining is the main source of gains, the "simpler" `FastU8` impl from the ssz_types PR actually turns out to be 3% slower than just inlining the current impl.

TODO:

- [ ] Confirm performance benefit for other uint types.