### PR TITLE
Remove minimum length of 1 in bitfield bytes

### DIFF
--- a/ssz/src/bitfield.rs
+++ b/ssz/src/bitfield.rs
@@ -563,10 +563,8 @@ impl<T> core::hash::Hash for Bitfield<T> {
 }
 
 /// Returns the minimum required bytes to represent a given number of bits.
-///
-/// `bit_len == 0` requires a single byte.
 fn bytes_for_bit_len(bit_len: usize) -> usize {
-    std::cmp::max(1, bit_len.div_ceil(8))
+    bit_len.div_ceil(8)
 }
 
 /// An iterator over the bits in a `Bitfield`.


### PR DESCRIPTION
Fix for the issue described here:

- https://github.com/ethereum/consensus-specs/issues/4795

We previously got away with this because regular merkleization always pads empty inputs to at least 1 chunk.

This PR is WIP, we probably also need to update the validation in `from_raw_bytes` which is now failing.