### PR TITLE
Use workspace publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,25 +7,20 @@ jobs:
   check-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Check version
         run: |
           TAG_VERSION=$(echo ${GITHUB_REF#refs/tags/v})
           CRATE_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
           test "$TAG_VERSION" = "$CRATE_VERSION"
+
   publish:
+    name: Publish to crates.io
     runs-on: ubuntu-latest
     needs: check-version
     env:
-      CARGO_REGISTRY_TOKEN: "${{ secrets.CARGO_REGISTRY_TOKEN }}"
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
-      - name: Publish derive crate
-        run: cargo publish -p ethereum_ssz_derive
-      # `ethereum_ssz` depends on `ethereum_ssz_derive` to publish, so sleep a
-      # bit to give crates.io some time to update.
-      - name: Sleep for 3 minutes
-        run: sleep 180s
-        shell: bash
-      - name: Publish main crate
-        run: cargo publish -p ethereum_ssz
+      - uses: actions/checkout@v4
+      - name: Publish all crates in the workspace
+        run: cargo publish --workspace

--- a/ssz/Cargo.toml
+++ b/ssz/Cargo.toml
@@ -30,5 +30,5 @@ context_deserialize = { version = "0.2", optional = true }
 
 [dev-dependencies]
 alloy-primitives = { version = "1", features = ["getrandom"] }
-ethereum_ssz_derive.workspace = true
+ethereum_ssz_derive = { path = "../ssz_derive" }
 serde_json = "1"

--- a/ssz_derive/Cargo.toml
+++ b/ssz_derive/Cargo.toml
@@ -21,4 +21,4 @@ quote = "1"
 darling = "0.23"
 
 [dev-dependencies]
-ethereum_ssz.workspace = true
+ethereum_ssz = { path = "../ssz" }


### PR DESCRIPTION
Following #76 the release workflow broke since `ethereum_ssz_derive` now looks for `ethereum_ssz`'s new version before it is published.

The easiest solution is to revert to using paths for each crates dev-dependencies.
This PR also uses workspace publishing instead as this is a better pattern than sequential publishing with a sleep in between.