### PR TITLE
Implement `not` and `not_inplace` for Bitfields

### DIFF
--- a/ssz/src/bitfield.rs
+++ b/ssz/src/bitfield.rs
@@ -757,6 +757,8 @@ impl<N: 'static + Unsigned> arbitrary::Arbitrary<'_> for Bitfield<Variable<N>> {
 
 #[cfg(test)]
 mod bitvector {
+    use std::str::RSplitTerminator;
+
     use super::*;
     use crate::BitVector;
 
@@ -966,6 +968,10 @@ mod bitvector {
 
     #[test]
     fn not() {
+        // Test empty
+        let empty = BitVector0::new();
+        assert_eq(empty.not(), empty);
+
         // Test with all zeros
         let a = BitVector8::new();
         let mut expected = BitVector8::new();

--- a/ssz/src/bitfield.rs
+++ b/ssz/src/bitfield.rs
@@ -461,7 +461,7 @@ impl<T: BitfieldBehaviour> Bitfield<T> {
             })
         } else {
             // Ensure there are no bits higher than `bit_len` that are set to true.
-            let (mask, _) = u8::MAX.overflowing_shr(8 - (bit_len as u32 % 8));
+            let mask = last_byte_mask(bit_len);
 
             if (bytes.last().expect("Guarded against empty bytes") & !mask) == 0 {
                 Ok(Self {
@@ -523,7 +523,7 @@ impl<T: BitfieldBehaviour> Bitfield<T> {
         }
     }
 
-    /// Perform a bitwise-not operation on the bits in `self`.
+    /// Perform a bitwise-not operation on the bits in `self`. Creates a new Bitfield.
     pub fn not(&self) -> Self {
         let mut result = self.clone();
         result.not_inplace();
@@ -532,16 +532,12 @@ impl<T: BitfieldBehaviour> Bitfield<T> {
 
     /// Perform a bitwise-not operation on the bits in `self`.
     pub fn not_inplace(&mut self) {
-        if self.len == 0 {
-            return;
-        }
         for byte in self.bytes.iter_mut() {
             *byte = !*byte;
         }
         // Mask out any bits higher than `self.len`.
         if let Some(last_byte) = self.bytes.last_mut() {
-            let mask = 0xFF >> (self.len % 8);
-            *last_byte &= mask;
+            *last_byte &= last_byte_mask(self.len);
         }
     }
 
@@ -566,6 +562,18 @@ impl<T: BitfieldBehaviour> Bitfield<T> {
             })
         }
     }
+}
+
+/// Return the bitmask appropriate for the last byte of the internal representation for a bitfield
+/// of length `len`. Notably, this function also returns the correct mask for length zero.
+///
+/// This should be applied via bitwise AND.
+fn last_byte_mask(len: usize) -> u8 {
+    // If the length is zero, the last byte is always zero.
+    if len == 0 {
+        return 0;
+    }
+    u8::MAX.wrapping_shr((8 - (len % 8)) as u32)
 }
 
 impl<T> Eq for Bitfield<T> {}
@@ -719,11 +727,8 @@ impl<N: 'static + Unsigned> arbitrary::Arbitrary<'_> for Bitfield<Fixed<N>> {
         let mut vec = smallvec![0u8; num_bytes];
         u.fill_buffer(&mut vec)?;
         // Mask out any excess bits in the last byte.
-        let used_bits = N::to_usize() % 8;
-        if used_bits > 0 {
-            if let Some(last) = vec.last_mut() {
-                *last &= (1u8 << used_bits) - 1;
-            }
+        if let Some(last) = vec.last_mut() {
+            *last &= last_byte_mask(self.len);
         }
         Self::from_bytes(vec).map_err(|_| arbitrary::Error::IncorrectFormat)
     }
@@ -748,7 +753,7 @@ impl<N: 'static + Unsigned> arbitrary::Arbitrary<'_> for Bitfield<Variable<N>> {
         let length_bit_byte = len / 8;
         let length_bit_pos = len % 8;
         // Clear bytes at or above `length_bit_pos`.
-        vec[length_bit_byte] &= (1u8 << length_bit_pos) - 1;
+        vec[length_bit_byte] &= last_byte_mask(len);
         // Set the length bit.
         vec[length_bit_byte] |= 1u8 << length_bit_pos;
         Self::from_bytes(vec).map_err(|_| arbitrary::Error::IncorrectFormat)
@@ -1602,10 +1607,13 @@ mod bitlist {
         let e = BitList8::from_raw_bytes(smallvec![0b0001_1111], 5).unwrap();
         let expected_e = BitList8::from_raw_bytes(smallvec![0b0000_0000], 5).unwrap();
         assert_eq!(e.not(), expected_e);
+        let f = BitList8::from_raw_bytes(smallvec![0b0000_0001], 5).unwrap();
+        let expected_f = BitList8::from_raw_bytes(smallvec![0b0001_1110], 5).unwrap();
+        assert_eq!(f.not(), expected_f);
 
         // Test with zero-length bitlist
-        let f = BitList0::with_capacity(0).unwrap();
-        assert_eq!(f.not(), f);
+        let g = BitList0::with_capacity(0).unwrap();
+        assert_eq!(g.not(), g);
     }
 
     #[test]

--- a/ssz/src/bitfield.rs
+++ b/ssz/src/bitfield.rs
@@ -540,7 +540,7 @@ impl<T: BitfieldBehaviour> Bitfield<T> {
         }
         // Mask out any bits higher than `self.len`.
         if let Some(last_byte) = self.bytes.last_mut() {
-            let mask = 0xFF >> self.len % 8;
+            let mask = 0xFF >> (self.len % 8);
             *last_byte &= mask;
         }
     }

--- a/ssz/src/bitfield.rs
+++ b/ssz/src/bitfield.rs
@@ -532,6 +532,9 @@ impl<T: BitfieldBehaviour> Bitfield<T> {
 
     /// Perform a bitwise-not operation on the bits in `self`.
     pub fn not_inplace(&mut self) {
+        if self.len == 0 {
+            return;
+        }
         for byte in self.bytes.iter_mut() {
             *byte = !*byte;
         }
@@ -959,6 +962,65 @@ mod bitvector {
     fn display() {
         let bitvec = BitVector16::from_bytes(smallvec![0b0010_1011, 0b0010_1110]).unwrap();
         assert_eq!("1101010001110100", bitvec.to_string());
+    }
+
+    #[test]
+    fn not() {
+        // Test with all zeros
+        let a = BitVector8::new();
+        let mut expected = BitVector8::new();
+        for i in 0..8 {
+            expected.set(i, true).unwrap();
+        }
+        assert_eq!(a.not(), expected);
+
+        // Test with all ones
+        let b = expected.clone();
+        assert_eq!(b.not(), BitVector8::new());
+
+        // Test with mixed pattern
+        let c = BitVector16::from_raw_bytes(smallvec![0b1100_1010, 0b0011_0101], 16).unwrap();
+        let expected_c = BitVector16::from_raw_bytes(smallvec![0b0011_0101, 0b1100_1010], 16).unwrap();
+        assert_eq!(c.not(), expected_c);
+
+        // Test with partial byte (4 bits)
+        let d = BitVector4::from_raw_bytes(smallvec![0b0000_1010], 4).unwrap();
+        let expected_d = BitVector4::from_raw_bytes(smallvec![0b0000_0101], 4).unwrap();
+        assert_eq!(d.not(), expected_d);
+
+        // Test that masking works correctly for partial bytes
+        let e = BitVector4::from_raw_bytes(smallvec![0b0000_1111], 4).unwrap();
+        let expected_e = BitVector4::from_raw_bytes(smallvec![0b0000_0000], 4).unwrap();
+        assert_eq!(e.not(), expected_e);
+    }
+
+    #[test]
+    fn not_inplace() {
+        // Test with all zeros
+        let mut a = BitVector8::new();
+        a.not_inplace();
+        let mut expected = BitVector8::new();
+        for i in 0..8 {
+            expected.set(i, true).unwrap();
+        }
+        assert_eq!(a, expected);
+
+        // Test with all ones
+        let mut b = expected.clone();
+        b.not_inplace();
+        assert_eq!(b, BitVector8::new());
+
+        // Test with mixed pattern
+        let mut c = BitVector16::from_raw_bytes(smallvec![0b1100_1010, 0b0011_0101], 16).unwrap();
+        c.not_inplace();
+        let expected_c = BitVector16::from_raw_bytes(smallvec![0b0011_0101, 0b1100_1010], 16).unwrap();
+        assert_eq!(c, expected_c);
+
+        // Test with partial byte (4 bits)
+        let mut d = BitVector4::from_raw_bytes(smallvec![0b0000_1010], 4).unwrap();
+        d.not_inplace();
+        let expected_d = BitVector4::from_raw_bytes(smallvec![0b0000_0101], 4).unwrap();
+        assert_eq!(d, expected_d);
     }
 }
 
@@ -1503,5 +1565,74 @@ mod bitlist {
     fn display() {
         let bitlist = BitList1024::from_raw_bytes(smallvec![0b0011_1111, 0b0001_0101], 15).unwrap();
         assert_eq!("111111001010100", bitlist.to_string());
+    }
+
+    #[test]
+    fn not() {
+        // Test with all zeros
+        let a = BitList8::with_capacity(8).unwrap();
+        let mut expected = BitList8::with_capacity(8).unwrap();
+        for i in 0..8 {
+            expected.set(i, true).unwrap();
+        }
+        assert_eq!(a.not(), expected);
+
+        // Test with all ones
+        let b = expected.clone();
+        assert_eq!(b.not(), BitList8::with_capacity(8).unwrap());
+
+        // Test with mixed pattern
+        let c = BitList16::from_raw_bytes(smallvec![0b1100_1010, 0b0011_0101], 16).unwrap();
+        let expected_c = BitList16::from_raw_bytes(smallvec![0b0011_0101, 0b1100_1010], 16).unwrap();
+        assert_eq!(c.not(), expected_c);
+
+        // Test with partial byte (5 bits)
+        let d = BitList8::from_raw_bytes(smallvec![0b0001_1010], 5).unwrap();
+        let expected_d = BitList8::from_raw_bytes(smallvec![0b0000_0101], 5).unwrap();
+        assert_eq!(d.not(), expected_d);
+
+        // Test that masking works correctly for partial bytes
+        let e = BitList8::from_raw_bytes(smallvec![0b0001_1111], 5).unwrap();
+        let expected_e = BitList8::from_raw_bytes(smallvec![0b0000_0000], 5).unwrap();
+        assert_eq!(e.not(), expected_e);
+
+        // Test with zero-length bitlist
+        let f = BitList0::with_capacity(0).unwrap();
+        assert_eq!(f.not(), f);
+    }
+
+    #[test]
+    fn not_inplace() {
+        // Test with all zeros
+        let mut a = BitList8::with_capacity(8).unwrap();
+        a.not_inplace();
+        let mut expected = BitList8::with_capacity(8).unwrap();
+        for i in 0..8 {
+            expected.set(i, true).unwrap();
+        }
+        assert_eq!(a, expected);
+
+        // Test with all ones
+        let mut b = expected.clone();
+        b.not_inplace();
+        assert_eq!(b, BitList8::with_capacity(8).unwrap());
+
+        // Test with mixed pattern
+        let mut c = BitList16::from_raw_bytes(smallvec![0b1100_1010, 0b0011_0101], 16).unwrap();
+        c.not_inplace();
+        let expected_c = BitList16::from_raw_bytes(smallvec![0b0011_0101, 0b1100_1010], 16).unwrap();
+        assert_eq!(c, expected_c);
+
+        // Test with partial byte (5 bits)
+        let mut d = BitList8::from_raw_bytes(smallvec![0b0001_1010], 5).unwrap();
+        d.not_inplace();
+        let expected_d = BitList8::from_raw_bytes(smallvec![0b0000_0101], 5).unwrap();
+        assert_eq!(d, expected_d);
+
+        // Test with zero-length bitlist
+        let mut f = BitList0::with_capacity(0).unwrap();
+        let expected_f = f.clone();
+        f.not_inplace();
+        assert_eq!(f, expected_f);
     }
 }

--- a/ssz/src/bitfield.rs
+++ b/ssz/src/bitfield.rs
@@ -523,6 +523,25 @@ impl<T: BitfieldBehaviour> Bitfield<T> {
         }
     }
 
+    /// Perform a bitwise-not operation on the bits in `self`.
+    pub fn not(&self) -> Self {
+        let mut result = self.clone();
+        result.not_inplace();
+        result
+    }
+
+    /// Perform a bitwise-not operation on the bits in `self`.
+    pub fn not_inplace(&mut self) {
+        for byte in self.bytes.iter_mut() {
+            *byte = !*byte;
+        }
+        // Mask out any bits higher than `self.len`.
+        if let Some(last_byte) = self.bytes.last_mut() {
+            let mask = 0xFF >> self.len % 8;
+            *last_byte &= mask;
+        }
+    }
+
     /// Shift the bits to higher indices, filling the lower indices with zeroes.
     ///
     /// The amount to shift by, `n`, must be less than or equal to `self.len()`.

--- a/ssz/src/bitfield.rs
+++ b/ssz/src/bitfield.rs
@@ -968,7 +968,7 @@ mod bitvector {
     fn not() {
         // Test empty
         let empty = BitVector0::new();
-        assert_eq(empty.not(), empty);
+        assert_eq!(empty.not(), empty);
 
         // Test with all zeros
         let a = BitVector8::new();

--- a/ssz/src/bitfield.rs
+++ b/ssz/src/bitfield.rs
@@ -728,7 +728,7 @@ impl<N: 'static + Unsigned> arbitrary::Arbitrary<'_> for Bitfield<Fixed<N>> {
         u.fill_buffer(&mut vec)?;
         // Mask out any excess bits in the last byte.
         if let Some(last) = vec.last_mut() {
-            *last &= last_byte_mask(self.len);
+            *last &= last_byte_mask(N::to_usize());
         }
         Self::from_bytes(vec).map_err(|_| arbitrary::Error::IncorrectFormat)
     }

--- a/ssz/src/bitfield.rs
+++ b/ssz/src/bitfield.rs
@@ -757,8 +757,6 @@ impl<N: 'static + Unsigned> arbitrary::Arbitrary<'_> for Bitfield<Variable<N>> {
 
 #[cfg(test)]
 mod bitvector {
-    use std::str::RSplitTerminator;
-
     use super::*;
     use crate::BitVector;
 

--- a/ssz/src/bitfield.rs
+++ b/ssz/src/bitfield.rs
@@ -980,7 +980,8 @@ mod bitvector {
 
         // Test with mixed pattern
         let c = BitVector16::from_raw_bytes(smallvec![0b1100_1010, 0b0011_0101], 16).unwrap();
-        let expected_c = BitVector16::from_raw_bytes(smallvec![0b0011_0101, 0b1100_1010], 16).unwrap();
+        let expected_c =
+            BitVector16::from_raw_bytes(smallvec![0b0011_0101, 0b1100_1010], 16).unwrap();
         assert_eq!(c.not(), expected_c);
 
         // Test with partial byte (4 bits)
@@ -1013,7 +1014,8 @@ mod bitvector {
         // Test with mixed pattern
         let mut c = BitVector16::from_raw_bytes(smallvec![0b1100_1010, 0b0011_0101], 16).unwrap();
         c.not_inplace();
-        let expected_c = BitVector16::from_raw_bytes(smallvec![0b0011_0101, 0b1100_1010], 16).unwrap();
+        let expected_c =
+            BitVector16::from_raw_bytes(smallvec![0b0011_0101, 0b1100_1010], 16).unwrap();
         assert_eq!(c, expected_c);
 
         // Test with partial byte (4 bits)
@@ -1583,7 +1585,8 @@ mod bitlist {
 
         // Test with mixed pattern
         let c = BitList16::from_raw_bytes(smallvec![0b1100_1010, 0b0011_0101], 16).unwrap();
-        let expected_c = BitList16::from_raw_bytes(smallvec![0b0011_0101, 0b1100_1010], 16).unwrap();
+        let expected_c =
+            BitList16::from_raw_bytes(smallvec![0b0011_0101, 0b1100_1010], 16).unwrap();
         assert_eq!(c.not(), expected_c);
 
         // Test with partial byte (5 bits)
@@ -1620,7 +1623,8 @@ mod bitlist {
         // Test with mixed pattern
         let mut c = BitList16::from_raw_bytes(smallvec![0b1100_1010, 0b0011_0101], 16).unwrap();
         c.not_inplace();
-        let expected_c = BitList16::from_raw_bytes(smallvec![0b0011_0101, 0b1100_1010], 16).unwrap();
+        let expected_c =
+            BitList16::from_raw_bytes(smallvec![0b0011_0101, 0b1100_1010], 16).unwrap();
         assert_eq!(c, expected_c);
 
         // Test with partial byte (5 bits)

--- a/ssz/src/bitfield/bitvector_dynamic.rs
+++ b/ssz/src/bitfield/bitvector_dynamic.rs
@@ -399,6 +399,72 @@ mod dynamic_bitfield_tests {
     }
 
     #[test]
+    fn test_not() -> Result<(), Error> {
+        // Test with all zeros -> all ones
+        let a = BitVectorDynamic::new(8)?;
+        let mut expected = BitVectorDynamic::new(8)?;
+        for i in 0..8 {
+            expected.set(i, true)?;
+        }
+        assert_eq!(a.not(), expected);
+
+        // Test with all ones -> all zeros
+        let b = expected.clone();
+        assert_eq!(b.not(), BitVectorDynamic::new(8)?);
+
+        // Test with mixed pattern (16 bits)
+        let c = BitVectorDynamic::from_bytes_with_len(smallvec![0b1100_1010, 0b0011_0101], 16)?;
+        let expected_c =
+            BitVectorDynamic::from_bytes_with_len(smallvec![0b0011_0101, 0b1100_1010], 16)?;
+        assert_eq!(c.not(), expected_c);
+
+        // Test double not is identity
+        let mut d = BitVectorDynamic::new(16)?;
+        d.set(0, true)?;
+        d.set(5, true)?;
+        d.set(15, true)?;
+        assert_eq!(d.not().not(), d);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_not_inplace() -> Result<(), Error> {
+        // Test with all zeros
+        let mut a = BitVectorDynamic::new(8)?;
+        a.not_inplace();
+        let mut expected = BitVectorDynamic::new(8)?;
+        for i in 0..8 {
+            expected.set(i, true)?;
+        }
+        assert_eq!(a, expected);
+
+        // Test with all ones
+        let mut b = expected.clone();
+        b.not_inplace();
+        assert_eq!(b, BitVectorDynamic::new(8)?);
+
+        // Test with mixed pattern (16 bits)
+        let mut c = BitVectorDynamic::from_bytes_with_len(smallvec![0b1100_1010, 0b0011_0101], 16)?;
+        c.not_inplace();
+        let expected_c =
+            BitVectorDynamic::from_bytes_with_len(smallvec![0b0011_0101, 0b1100_1010], 16)?;
+        assert_eq!(c, expected_c);
+
+        // Test double not_inplace is identity
+        let mut d = BitVectorDynamic::new(16)?;
+        d.set(0, true)?;
+        d.set(5, true)?;
+        d.set(15, true)?;
+        let original = d.clone();
+        d.not_inplace();
+        d.not_inplace();
+        assert_eq!(d, original);
+
+        Ok(())
+    }
+
+    #[test]
     fn test_ssz_bytes_len() -> Result<(), Error> {
         let bitfield = BitVectorDynamic::new(16)?; // 16 bits = 2 bytes
         assert_eq!(bitfield.ssz_bytes_len(), 2);


### PR DESCRIPTION
It is incredibly annoying to `not` a bitfield manually. 

You have to use `set` for each index separately, which is each a fallible operation.

Even if you are feeling smart and try to do something like creating an all ones bitvector and using `difference_inplace` to create the bitwise not, you will notice that there is no easy way to create an all ones bitvector (which this PR will also help with).

`not` and `not_inplace` follows the existing pattern of `difference` and `difference_inplace`.