### PR TITLE
Pre-allocate in `as_ssz_bytes`

### DIFF
--- a/ssz/src/encode.rs
+++ b/ssz/src/encode.rs
@@ -37,7 +37,7 @@ pub trait Encode {
     ///
     /// The default implementation of this method should suffice for most cases.
     fn as_ssz_bytes(&self) -> Vec<u8> {
-        let mut buf = vec![];
+        let mut buf = Vec::with_capacity(self.ssz_bytes_len());
 
         self.ssz_append(&mut buf);
 


### PR DESCRIPTION
During encoding, we can pre-allocate the output buffer since we already know the final SSZ length.
This avoids potential re-allocations as the buffer grows during encoding.

From my rough testing, this typically saves around 5-10% with gains up to 50% depending on how much allocation and re-allocation overhead dominates the encoding time