### PR TITLE
Do not fail CI on coverage error

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -56,5 +56,5 @@ jobs:
     - name: Upload to codecov.io
       uses: codecov/codecov-action@v4
       with:
-        fail_ci_if_error: true
+        fail_ci_if_error: false
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
It is quite frequent to get "false positives" on coverage. Where coverage percentage is unchanged yet the CI task still fails.

This doesn't block merging, but does lead to an ugly red error on the PR which is unnecessary. We can see coverage regressions manually so we should forgo this error.

This PR switches `fail_ci_if_error` to false.