### PR TITLE
Support no_std builds

### DIFF
--- a/ssz/Cargo.toml
+++ b/ssz/Cargo.toml
@@ -14,17 +14,19 @@ categories.workspace = true
 name = "ssz"
 
 [features]
+default = ["std"]
+std = ["alloy-primitives/std", "ethereum_serde_utils/std", "serde/std", "itertools/use_std"]
 arbitrary = ["dep:arbitrary", "alloy-primitives/arbitrary"]
 context_deserialize = ["dep:context_deserialize"]
 
 [dependencies]
-alloy-primitives = "1"
-ethereum_serde_utils = "0.8"
-smallvec = { version = "1", features = ["const_generics"] }
-itertools = "0.14"
-serde = "1"
+alloy-primitives = { version = "1", default-features = false }
+ethereum_serde_utils = { version = "0.8", default-features = false }
+smallvec = { version = "1", default-features = false, features = ["const_generics"] }
+itertools = { version = "0.14", default-features = false, features = ["use_alloc"] }
+serde = { version = "1", default-features = false, features = ["alloc"] }
 serde_derive = "1"
-typenum = "1"
+typenum = { version = "1", default-features = false }
 arbitrary = { version = "1", features = ["derive"], optional = true }
 context_deserialize = { version = "0.2", optional = true }
 

--- a/ssz/src/bitfield.rs
+++ b/ssz/src/bitfield.rs
@@ -365,6 +365,13 @@ impl<T: BitfieldBehaviour> core::fmt::Display for Bitfield<T> {
     }
 }
 
+/// An empty bit list, mirroring the fixed variant's `Default`. Zero length is a valid `BitList`.
+impl<N: Unsigned + Clone> Default for Bitfield<Variable<N>> {
+    fn default() -> Self {
+        Self::with_capacity(0).expect("a zero length bitlist is within any bound")
+    }
+}
+
 impl<N: Unsigned + Clone> Default for Bitfield<Fixed<N>> {
     fn default() -> Self {
         Self::new()

--- a/ssz/src/bitfield.rs
+++ b/ssz/src/bitfield.rs
@@ -1,3 +1,4 @@
+use alloc::{string::{String, ToString}, vec::Vec};
 use crate::{Decode, DecodeError, Encode};
 use core::marker::PhantomData;
 use serde::de::{Deserialize, Deserializer};
@@ -230,7 +231,7 @@ impl<N: Unsigned + Clone> Bitfield<Variable<N>> {
     ///
     /// Return a new BitList with length equal to the shorter of the two inputs.
     pub fn intersection(&self, other: &Self) -> Self {
-        let min_len = std::cmp::min(self.len(), other.len());
+        let min_len = core::cmp::min(self.len(), other.len());
         let mut result = Self::with_capacity(min_len).expect("min len always less than N");
         // Bitwise-and the bytes together, starting from the left of each vector. This takes care
         // of masking out any entries beyond `min_len` as well, assuming the bitfield doesn't
@@ -245,7 +246,7 @@ impl<N: Unsigned + Clone> Bitfield<Variable<N>> {
     ///
     /// Return a new BitList with length equal to the longer of the two inputs.
     pub fn union(&self, other: &Self) -> Self {
-        let max_len = std::cmp::max(self.len(), other.len());
+        let max_len = core::cmp::max(self.len(), other.len());
         let mut result = Self::with_capacity(max_len).expect("max len always less than N");
         for i in 0..result.bytes.len() {
             result.bytes[i] =
@@ -350,8 +351,8 @@ impl<N: Unsigned + Clone> Bitfield<Fixed<N>> {
     }
 }
 
-impl<T: BitfieldBehaviour> std::fmt::Display for Bitfield<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<T: BitfieldBehaviour> core::fmt::Display for Bitfield<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut field: String = "".to_string();
         for i in self.iter() {
             if i {
@@ -514,7 +515,7 @@ impl<T: BitfieldBehaviour> Bitfield<T> {
 
     /// Compute the difference of this Bitfield and another of potentially different length.
     pub fn difference_inplace(&mut self, other: &Self) {
-        let min_byte_len = std::cmp::min(self.bytes.len(), other.bytes.len());
+        let min_byte_len = core::cmp::min(self.bytes.len(), other.bytes.len());
 
         for i in 0..min_byte_len {
             self.bytes[i] &= !other.bytes[i];
@@ -599,7 +600,7 @@ impl<T> core::hash::Hash for Bitfield<T> {
 ///
 /// `bit_len == 0` requires a single byte.
 fn bytes_for_bit_len(bit_len: usize) -> usize {
-    std::cmp::max(1, bit_len.div_ceil(8))
+    core::cmp::max(1, bit_len.div_ceil(8))
 }
 
 /// Returns the number of bytes in the SSZ encoding of a variable-length bitfield (`BitList` or
@@ -957,7 +958,7 @@ mod bitvector {
         assert_round_trip(b);
     }
 
-    fn assert_round_trip<T: Encode + Decode + PartialEq + std::fmt::Debug>(t: T) {
+    fn assert_round_trip<T: Encode + Decode + PartialEq + core::fmt::Debug>(t: T) {
         assert_eq!(T::from_ssz_bytes(&t.as_ssz_bytes()).unwrap(), t);
     }
 
@@ -983,7 +984,7 @@ mod bitvector {
     // Ensure that stack size of a BitVector is manageable.
     #[test]
     fn size_of() {
-        assert_eq!(std::mem::size_of::<BitVector64>(), SMALLVEC_LEN + 24);
+        assert_eq!(core::mem::size_of::<BitVector64>(), SMALLVEC_LEN + 24);
     }
 
     #[test]
@@ -1203,7 +1204,7 @@ mod bitlist {
         }
     }
 
-    fn assert_round_trip<T: Encode + Decode + PartialEq + std::fmt::Debug>(t: T) {
+    fn assert_round_trip<T: Encode + Decode + PartialEq + core::fmt::Debug>(t: T) {
         assert_eq!(T::from_ssz_bytes(&t.as_ssz_bytes()).unwrap(), t);
     }
 
@@ -1569,7 +1570,7 @@ mod bitlist {
     // Ensure that the stack size of a BitList is manageable.
     #[test]
     fn size_of() {
-        assert_eq!(std::mem::size_of::<BitList1024>(), SMALLVEC_LEN + 24);
+        assert_eq!(core::mem::size_of::<BitList1024>(), SMALLVEC_LEN + 24);
     }
 
     #[test]

--- a/ssz/src/bitfield.rs
+++ b/ssz/src/bitfield.rs
@@ -1,5 +1,8 @@
-use alloc::{string::{String, ToString}, vec::Vec};
 use crate::{Decode, DecodeError, Encode};
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 use core::marker::PhantomData;
 use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};

--- a/ssz/src/bitfield/bitvector_dynamic.rs
+++ b/ssz/src/bitfield/bitvector_dynamic.rs
@@ -151,8 +151,8 @@ mod dynamic_bitfield_tests {
         assert!(bitfield.set(15, true).is_ok());
         assert!(bitfield.set(16, true).is_err()); // Out of bounds
 
-        assert_eq!(bitfield.get(0)?, true);
-        assert_eq!(bitfield.get(15)?, true);
+        assert!(bitfield.get(0)?);
+        assert!(bitfield.get(15)?);
         assert!(bitfield.get(16).is_err());
 
         Ok(())
@@ -278,9 +278,9 @@ mod dynamic_bitfield_tests {
         b.set(4, true)?;
 
         let diff = a.difference(&b);
-        assert_eq!(diff.get(1)?, true);
-        assert_eq!(diff.get(3)?, false);
-        assert_eq!(diff.get(4)?, false);
+        assert!(diff.get(1)?);
+        assert!(!diff.get(3)?);
+        assert!(!diff.get(4)?);
 
         Ok(())
     }
@@ -292,9 +292,9 @@ mod dynamic_bitfield_tests {
         bitfield.set(1, true)?;
 
         bitfield.shift_up(1)?;
-        assert_eq!(bitfield.get(0)?, false);
-        assert_eq!(bitfield.get(1)?, true);
-        assert_eq!(bitfield.get(2)?, true);
+        assert!(!bitfield.get(0)?);
+        assert!(bitfield.get(1)?);
+        assert!(bitfield.get(2)?);
 
         // Test error case
         assert!(bitfield.shift_up(17).is_err());

--- a/ssz/src/bitfield/bitvector_dynamic.rs
+++ b/ssz/src/bitfield/bitvector_dynamic.rs
@@ -1,5 +1,6 @@
 //! Provides `Bitfield<Dynamic>` (BitVectorDynamic)
 /// for encoding and decoding bitvectors that have a dynamic length.
+use alloc::vec::Vec;
 use crate::{
     bitfield::{bytes_for_bit_len, Bitfield, BitfieldBehaviour, Error, SMALLVEC_LEN},
     Decode, DecodeError, Encode,
@@ -63,7 +64,7 @@ impl Bitfield<Dynamic> {
 
     /// Compute the intersection of two bitfields.
     pub fn intersection(&self, other: &Self) -> Result<Self, Error> {
-        let max_len = std::cmp::max(self.len(), other.len());
+        let max_len = core::cmp::max(self.len(), other.len());
         let mut result = Self::new(max_len)?;
 
         for (i, byte) in result.bytes.iter_mut().enumerate() {
@@ -75,7 +76,7 @@ impl Bitfield<Dynamic> {
 
     /// Compute the union of two bitfields.
     pub fn union(&self, other: &Self) -> Result<Self, Error> {
-        let max_len = std::cmp::max(self.len(), other.len());
+        let max_len = core::cmp::max(self.len(), other.len());
         let mut result = Self::new(max_len)?;
 
         for (i, byte) in result.bytes.iter_mut().enumerate() {
@@ -480,7 +481,7 @@ mod roundtrip_tests {
     use super::*;
     fn assert_round_trip_bitdyn<T>(t: T) -> Result<(), Error>
     where
-        T: Encode + Decode + PartialEq + std::fmt::Debug,
+        T: Encode + Decode + PartialEq + core::fmt::Debug,
     {
         let bytes = t.as_ssz_bytes();
         let decoded = T::from_ssz_bytes(&bytes).expect("decode failed in test");

--- a/ssz/src/bitfield/bitvector_dynamic.rs
+++ b/ssz/src/bitfield/bitvector_dynamic.rs
@@ -1,10 +1,10 @@
 //! Provides `Bitfield<Dynamic>` (BitVectorDynamic)
-/// for encoding and decoding bitvectors that have a dynamic length.
-use alloc::vec::Vec;
 use crate::{
     bitfield::{bytes_for_bit_len, Bitfield, BitfieldBehaviour, Error, SMALLVEC_LEN},
     Decode, DecodeError, Encode,
 };
+/// for encoding and decoding bitvectors that have a dynamic length.
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};

--- a/ssz/src/bitfield/progressive.rs
+++ b/ssz/src/bitfield/progressive.rs
@@ -1,6 +1,5 @@
 //! Provides `Bitfield<Progressive>` (ProgressiveBitList)
 //! for encoding and decoding bitlists that have no capacity limit.
-use alloc::vec::Vec;
 use crate::{
     bitfield::{
         bytes_for_bit_len, variable_bitfield_ssz_append, variable_bitfield_ssz_bytes_len, Bitfield,
@@ -8,6 +7,7 @@ use crate::{
     },
     Decode, DecodeError, Encode,
 };
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
@@ -703,7 +703,10 @@ mod progressive_bitlist {
     // Ensure that the stack size of a ProgressiveBitList is manageable.
     #[test]
     fn size_of() {
-        assert_eq!(core::mem::size_of::<ProgressiveBitList>(), SMALLVEC_LEN + 24);
+        assert_eq!(
+            core::mem::size_of::<ProgressiveBitList>(),
+            SMALLVEC_LEN + 24
+        );
     }
 
     #[test]

--- a/ssz/src/bitfield/progressive.rs
+++ b/ssz/src/bitfield/progressive.rs
@@ -1,5 +1,6 @@
 //! Provides `Bitfield<Progressive>` (ProgressiveBitList)
 //! for encoding and decoding bitlists that have no capacity limit.
+use alloc::vec::Vec;
 use crate::{
     bitfield::{
         bytes_for_bit_len, variable_bitfield_ssz_append, variable_bitfield_ssz_bytes_len, Bitfield,
@@ -108,7 +109,7 @@ impl Bitfield<Progressive> {
     ///
     /// Return a new ProgressiveBitList with length equal to the shorter of the two inputs.
     pub fn intersection(&self, other: &Self) -> Self {
-        let min_len = std::cmp::min(self.len(), other.len());
+        let min_len = core::cmp::min(self.len(), other.len());
         let mut result = Self::with_capacity(min_len);
         // Bitwise-and the bytes together, starting from the left of each vector. This takes care
         // of masking out any entries beyond `min_len` as well, assuming the bitfield doesn't
@@ -123,7 +124,7 @@ impl Bitfield<Progressive> {
     ///
     /// Return a new ProgressiveBitList with length equal to the longer of the two inputs.
     pub fn union(&self, other: &Self) -> Self {
-        let max_len = std::cmp::max(self.len(), other.len());
+        let max_len = core::cmp::max(self.len(), other.len());
         let mut result = Self::with_capacity(max_len);
         for i in 0..result.bytes.len() {
             result.bytes[i] =
@@ -299,7 +300,7 @@ mod progressive_bitlist {
         }
     }
 
-    fn assert_round_trip<T: Encode + Decode + PartialEq + std::fmt::Debug>(t: T) {
+    fn assert_round_trip<T: Encode + Decode + PartialEq + core::fmt::Debug>(t: T) {
         assert_eq!(T::from_ssz_bytes(&t.as_ssz_bytes()).unwrap(), t);
     }
 
@@ -702,7 +703,7 @@ mod progressive_bitlist {
     // Ensure that the stack size of a ProgressiveBitList is manageable.
     #[test]
     fn size_of() {
-        assert_eq!(std::mem::size_of::<ProgressiveBitList>(), SMALLVEC_LEN + 24);
+        assert_eq!(core::mem::size_of::<ProgressiveBitList>(), SMALLVEC_LEN + 24);
     }
 
     #[test]

--- a/ssz/src/decode.rs
+++ b/ssz/src/decode.rs
@@ -1,6 +1,7 @@
+use alloc::string::String;
 use super::*;
 use smallvec::{smallvec, SmallVec};
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 
 type SmallVec8<T> = SmallVec<[T; 8]>;
 
@@ -368,7 +369,7 @@ fn decode_offset(bytes: &[u8]) -> Result<usize, DecodeError> {
     if len != expected {
         Err(DecodeError::InvalidLengthPrefix { len, expected })
     } else {
-        let mut array: [u8; BYTES_PER_LENGTH_OFFSET] = std::default::Default::default();
+        let mut array: [u8; BYTES_PER_LENGTH_OFFSET] = core::default::Default::default();
         array.clone_from_slice(bytes);
 
         Ok(u32::from_le_bytes(array) as usize)

--- a/ssz/src/decode.rs
+++ b/ssz/src/decode.rs
@@ -1,7 +1,7 @@
-use alloc::string::String;
 use super::*;
-use smallvec::{smallvec, SmallVec};
+use alloc::string::String;
 use core::cmp::Ordering;
+use smallvec::{smallvec, SmallVec};
 
 type SmallVec8<T> = SmallVec<[T; 8]>;
 

--- a/ssz/src/decode/impls.rs
+++ b/ssz/src/decode/impls.rs
@@ -1,13 +1,13 @@
-use alloc::{string::ToString, vec::Vec};
 use super::*;
 use crate::decode::try_from_iter::{TryCollect, TryFromIter};
+use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::sync::Arc;
+use alloc::{string::ToString, vec::Vec};
 use alloy_primitives::{Address, Bloom, Bytes, FixedBytes, U128, U256};
+use core::iter::{self, FromIterator};
 use core::num::NonZeroUsize;
 use itertools::process_results;
 use smallvec::SmallVec;
-use alloc::collections::{BTreeMap, BTreeSet};
-use core::iter::{self, FromIterator};
-use alloc::sync::Arc;
 
 macro_rules! impl_decodable_for_uint {
     ($type: ident, $bit_size: expr) => {

--- a/ssz/src/decode/impls.rs
+++ b/ssz/src/decode/impls.rs
@@ -1,12 +1,13 @@
+use alloc::{string::ToString, vec::Vec};
 use super::*;
 use crate::decode::try_from_iter::{TryCollect, TryFromIter};
 use alloy_primitives::{Address, Bloom, Bytes, FixedBytes, U128, U256};
 use core::num::NonZeroUsize;
 use itertools::process_results;
 use smallvec::SmallVec;
-use std::collections::{BTreeMap, BTreeSet};
-use std::iter::{self, FromIterator};
-use std::sync::Arc;
+use alloc::collections::{BTreeMap, BTreeSet};
+use core::iter::{self, FromIterator};
+use alloc::sync::Arc;
 
 macro_rules! impl_decodable_for_uint {
     ($type: ident, $bit_size: expr) => {
@@ -29,7 +30,7 @@ macro_rules! impl_decodable_for_uint {
                 if len != expected {
                     Err(DecodeError::InvalidByteLength { len, expected })
                 } else {
-                    let mut array: [u8; $bit_size / 8] = std::default::Default::default();
+                    let mut array: [u8; $bit_size / 8] = core::default::Default::default();
                     array.clone_from_slice(bytes);
 
                     Ok(Self::from_le_bytes(array))

--- a/ssz/src/decode/try_from_iter.rs
+++ b/ssz/src/decode/try_from_iter.rs
@@ -1,8 +1,8 @@
-use alloc::vec::Vec;
-use smallvec::SmallVec;
 use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::vec::Vec;
 use core::convert::Infallible;
 use core::fmt::Debug;
+use smallvec::SmallVec;
 
 /// Partial variant of `core::iter::FromIterator`.
 ///

--- a/ssz/src/decode/try_from_iter.rs
+++ b/ssz/src/decode/try_from_iter.rs
@@ -1,9 +1,10 @@
+use alloc::vec::Vec;
 use smallvec::SmallVec;
-use std::collections::{BTreeMap, BTreeSet};
-use std::convert::Infallible;
-use std::fmt::Debug;
+use alloc::collections::{BTreeMap, BTreeSet};
+use core::convert::Infallible;
+use core::fmt::Debug;
 
-/// Partial variant of `std::iter::FromIterator`.
+/// Partial variant of `core::iter::FromIterator`.
 ///
 /// This trait is implemented for types which can be constructed from an iterator of decoded SSZ
 /// values, but which may refuse values once a length limit is reached.

--- a/ssz/src/encode/impls.rs
+++ b/ssz/src/encode/impls.rs
@@ -1,9 +1,9 @@
 use super::*;
+use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::sync::Arc;
 use alloy_primitives::{Address, Bloom, Bytes, FixedBytes, U128, U256};
 use core::num::NonZeroUsize;
 use smallvec::SmallVec;
-use alloc::collections::{BTreeMap, BTreeSet};
-use alloc::sync::Arc;
 
 macro_rules! impl_encodable_for_uint {
     ($type: ident, $bit_size: expr) => {

--- a/ssz/src/encode/impls.rs
+++ b/ssz/src/encode/impls.rs
@@ -2,8 +2,8 @@ use super::*;
 use alloy_primitives::{Address, Bloom, Bytes, FixedBytes, U128, U256};
 use core::num::NonZeroUsize;
 use smallvec::SmallVec;
-use std::collections::{BTreeMap, BTreeSet};
-use std::sync::Arc;
+use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::sync::Arc;
 
 macro_rules! impl_encodable_for_uint {
     ($type: ident, $bit_size: expr) => {
@@ -404,7 +404,7 @@ impl Encode for NonZeroUsize {
     }
 
     fn ssz_bytes_len(&self) -> usize {
-        std::mem::size_of::<usize>()
+        core::mem::size_of::<usize>()
     }
 
     fn ssz_append(&self, buf: &mut Vec<u8>) {

--- a/ssz/src/legacy.rs
+++ b/ssz/src/legacy.rs
@@ -160,7 +160,7 @@ mod test {
         assert_eq!(impl_vec_u16::decode::from_ssz_bytes(&bytes).unwrap(), item);
     }
 
-    fn round_trip<T: Encode + Decode + std::fmt::Debug + PartialEq>(items: Vec<T>) {
+    fn round_trip<T: Encode + Decode + core::fmt::Debug + PartialEq>(items: Vec<T>) {
         for item in items {
             let encoded = &item.as_ssz_bytes();
             assert_eq!(item.ssz_bytes_len(), encoded.len());

--- a/ssz/src/lib.rs
+++ b/ssz/src/lib.rs
@@ -39,7 +39,8 @@
 #[macro_use]
 extern crate alloc;
 
-use alloc::vec::Vec;
+/// Re-exported so the derives can name `Vec` without relying on the consumer having imported it.
+pub use alloc::vec::Vec;
 
 mod bitfield;
 mod decode;

--- a/ssz/src/lib.rs
+++ b/ssz/src/lib.rs
@@ -34,6 +34,13 @@
 //!
 //! See `examples/` for manual implementations of the `Encode` and `Decode` traits.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[macro_use]
+extern crate alloc;
+
+use alloc::vec::Vec;
+
 mod bitfield;
 mod decode;
 mod encode;

--- a/ssz_derive/src/lib.rs
+++ b/ssz_derive/src/lib.rs
@@ -477,7 +477,7 @@ fn ssz_encode_derive_struct(derive_input: &DeriveInput, struct_data: &DataStruct
                 }
             }
 
-            fn ssz_append(&self, buf: &mut Vec<u8>) {
+            fn ssz_append(&self, buf: &mut ssz::Vec<u8>) {
                 let mut offset: usize = 0;
                 #(
                     offset = offset
@@ -548,7 +548,7 @@ fn ssz_encode_derive_struct_transparent(
                     self.#field_name.ssz_bytes_len()
                 }
 
-                fn ssz_append(&self, buf: &mut Vec<u8>) {
+                fn ssz_append(&self, buf: &mut ssz::Vec<u8>) {
                     self.#field_name.ssz_append(buf)
                 }
             }
@@ -568,7 +568,7 @@ fn ssz_encode_derive_struct_transparent(
                     self.#index.ssz_bytes_len()
                 }
 
-                fn ssz_append(&self, buf: &mut Vec<u8>) {
+                fn ssz_append(&self, buf: &mut ssz::Vec<u8>) {
                     self.#index.ssz_append(buf)
                 }
             }
@@ -643,7 +643,7 @@ fn ssz_encode_derive_enum_transparent(
                 }
             }
 
-            fn ssz_append(&self, buf: &mut Vec<u8>) {
+            fn ssz_append(&self, buf: &mut ssz::Vec<u8>) {
                 match self {
                     #(
                         #patterns => inner.ssz_append(buf),
@@ -709,7 +709,7 @@ fn ssz_encode_derive_enum_tag(derive_input: &DeriveInput, enum_data: &DataEnum) 
                 1
             }
 
-            fn ssz_append(&self, buf: &mut Vec<u8>) {
+            fn ssz_append(&self, buf: &mut ssz::Vec<u8>) {
                 match self {
                     #(
                         #patterns => {
@@ -783,7 +783,7 @@ fn ssz_encode_derive_enum_union(derive_input: &DeriveInput, enum_data: &DataEnum
                 }
             }
 
-            fn ssz_append(&self, buf: &mut Vec<u8>) {
+            fn ssz_append(&self, buf: &mut ssz::Vec<u8>) {
                 match self {
                     #(
                         #patterns => {
@@ -929,7 +929,7 @@ fn ssz_encode_derive_enum_compatible_union(
                 }
             }
 
-            fn ssz_append(&self, buf: &mut Vec<u8>) {
+            fn ssz_append(&self, buf: &mut ssz::Vec<u8>) {
                 match self {
                     #(
                         #patterns => {
@@ -1071,7 +1071,7 @@ fn ssz_decode_derive_struct(item: &DeriveInput, struct_data: &DataStruct) -> Tok
                 }
             }
 
-            fn from_ssz_bytes(__bytes: &[u8]) -> std::result::Result<Self, ssz::DecodeError> {
+            fn from_ssz_bytes(__bytes: &[u8]) -> core::result::Result<Self, ssz::DecodeError> {
                 if <Self as ssz::Decode>::is_ssz_fixed_len() {
                     if __bytes.len() != <Self as ssz::Decode>::ssz_fixed_len() {
                         return Err(ssz::DecodeError::InvalidByteLength {
@@ -1186,7 +1186,7 @@ fn ssz_decode_derive_struct_transparent(
                 <#ty as ssz::Decode>::ssz_fixed_len()
             }
 
-            fn from_ssz_bytes(__bytes: &[u8]) -> std::result::Result<Self, ssz::DecodeError> {
+            fn from_ssz_bytes(__bytes: &[u8]) -> core::result::Result<Self, ssz::DecodeError> {
                 Ok(Self {
                     #(
                         #fields
@@ -1232,7 +1232,7 @@ fn ssz_decode_derive_enum_tag(derive_input: &DeriveInput, enum_data: &DataEnum) 
                 1
             }
 
-            fn from_ssz_bytes(__bytes: &[u8]) -> std::result::Result<Self, ssz::DecodeError> {
+            fn from_ssz_bytes(__bytes: &[u8]) -> core::result::Result<Self, ssz::DecodeError> {
                 let byte = __bytes
                     .first()
                     .copied()


### PR DESCRIPTION
> **Draft: blocked on [ethereum_serde_utils#21](https://github.com/sigp/ethereum_serde_utils/pull/21).** CI here will fail dependency resolution until that is merged and released. Opened now so the whole series is visible rather than arriving piecemeal.

## What this does

Adds `no_std` support, so the crate can be used from a wasm runtime, plus two smaller changes that no_std consumers need.

## Why

Substrate runtimes compile to `wasm32-unknown-unknown` without `std`. Everything here is available in `core` and `alloc`.

## Changes

| Commit | What |
| --- | --- |
| Support no_std builds | crate gated on the `std` feature, `alloc` used where `std` was assumed |
| Give `BitList` a `Default` impl to match `BitVector` | `BitVector` already had one, the asymmetry is awkward for derived containers |
| Emit `core` paths from the derives | the generated code referenced `std::` paths, so it did not compile in a no_std consumer even when this crate itself did |
| Satisfy the current clippy lints | housekeeping the tooling flagged while working here |

The derive change is the one that matters most for downstream users. A no_std crate could depend on this one successfully and still fail to build the moment it used `#[derive(Encode)]`.

## Why it cannot build yet

This depends on `ethereum_serde_utils` with feature `std`, and the published 0.8.1 has no such feature: it is added by #21. Until that releases, cargo cannot resolve.

## Verification

Verified locally against the proposed `ethereum_serde_utils` branch via a path patch.

| Check | Result |
| --- | --- |
| `cargo test` | 123 + 41 passed |
| `cargo check --no-default-features --target wasm32-unknown-unknown` | clean |
| `cargo fmt --check` | no diffs |

## Where this sits

1. ethereum_hashing#23 and ethereum_serde_utils#21
2. **this PR**
3. tree_hash, then ssz_types

Happy to rework any of it, and glad to split the clippy commit out if you would rather review the no_std work alone.
